### PR TITLE
Disable upload to code-scanning dashboard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: results.sarif
+      # - name: "Upload to code-scanning"
+      #  uses: github/codeql-action/upload-sarif@v4
+      #  with:
+      #    sarif_file: results.sarif


### PR DESCRIPTION
Comment out the upload step for code scanning results.